### PR TITLE
Allow "vX.Y.Z" for version number in CHANGELOGs

### DIFF
--- a/lib/changelog/validator.rb
+++ b/lib/changelog/validator.rb
@@ -68,20 +68,20 @@ module Releasinator
 
       def validate_changelog_contents(changelog_contents)
         # Modified version of Vandamme::Parser::DEFAULT_REGEX to disallow versions with leading alpha characters
-        changelog_regex = Regexp.new('^#{0,3} ?([\d\.-]+\.[\w\d\.-]+[a-zA-Z0-9])(?: \W (\w+ \d{1,2}(?:st|nd|rd|th)?,\s\d{4}|\d{4}-\d{2}-\d{2}|\w+))?\n?[=-]*')
+        changelog_regex = Regexp.new('^#{0,3} ?(v?[\d\.-]+\.[\w\d\.-]+[a-zA-Z0-9])(?: \W (\w+ \d{1,2}(?:st|nd|rd|th)?,\s\d{4}|\d{4}-\d{2}-\d{2}|\w+))?\n?[=-]*')
         parser = Vandamme::Parser.new(changelog: changelog_contents, version_header_exp: changelog_regex, format: 'markdown')
         changelog_hash = parser.parse
-        
+
         if changelog_hash.empty?
           Printer.fail("Unable to find any releases in the CHANGELOG.md.  Please check that the formatting is correct.")
           abort()
         end
-        
+
         Printer.success("Found " + changelog_hash.count.to_s.bold + " release(s) in CHANGELOG.md.")
 
         validate_semver(changelog_hash)
 
-        changelog_hash.each { |release, changelog| 
+        changelog_hash.each { |release, changelog|
           validate_single_changelog_entry(changelog)
         }
 

--- a/test/changelog/test_validator.rb
+++ b/test/changelog/test_validator.rb
@@ -2,10 +2,10 @@ require "test/unit"
 require 'tempfile'
 require 'open-uri'
 require_relative "../../lib/changelog/validator"
- 
+
 class TestChangelogValidator < Test::Unit::TestCase
   include Releasinator
-  
+
   def setup
     config = {:verbose => false}
     @validator_changelog = Changelog::Validator.new(config)
@@ -29,7 +29,7 @@ class TestChangelogValidator < Test::Unit::TestCase
       @validator_changelog.validate_semver({ "99.99.0" => "", "99.98.99" => "" })
       @validator_changelog.validate_semver({ "99.99.99" => "", "99.99.98" => "" })
       @validator_changelog.validate_semver({ "99.99.99" => "", "99.99.98" => "" })
-    end 
+    end
   end
 
   def test_validate_semver_fail
@@ -54,7 +54,7 @@ class TestChangelogValidator < Test::Unit::TestCase
       @validator_changelog.validate_single_changelog_entry("* multiline \n success with extra newline.\n")
       @validator_changelog.validate_single_changelog_entry("* single line with extra newline success.\n")
       @validator_changelog.validate_single_changelog_entry("* In CocoaPods, add subspecs to allow PayPal SDK to be used without card.io. By\n  default, all libraries are included. If you do not want to use card.io, use the `Core` subspec like `PayPal-iOS-SDK/Core` in your Podfile. See the \n SampleApp without card.io to see how you can setup your application without\n  credit card scanning. See [issue #358](https://github.com/paypal/PayPal-iOS-SDK/issues/358).\n * Update to use NSURLSession whenever possible. Falls back to NSURLConnection for iOS 6.")
-    end 
+    end
   end
 
   def test_validate_bullets_fail
@@ -72,7 +72,7 @@ class TestChangelogValidator < Test::Unit::TestCase
       @validator_changelog.validate_semver({ "version1.1.0" => "", "version1.0.1" => "" })
       @validator_changelog.validate_semver({ "------------1.1.1" => "", "------------1.1.0" => "" })
       @validator_changelog.validate_semver({ "v1.1.1" => "", "v1.1.1-beta" => "" })
-    end 
+    end
   end
 
   def test_validate_semver_w_prefix_fail
@@ -96,10 +96,30 @@ class TestChangelogValidator < Test::Unit::TestCase
     end
   end
 
+  def test_validate_changelog_contents_one_dash_format_with_v_in_front
+    assert_nothing_raised do
+      contents = "v1.1.1\n----\ncontents"
+      expected_current_release = CurrentRelease.new("v1.1.1", "contents")
+      actual_current_release = @validator_changelog.validate_changelog_contents(contents)
+      assert_equal(expected_current_release.version, actual_current_release.version)
+      assert_equal(expected_current_release.changelog, actual_current_release.changelog)
+    end
+  end
+
   def test_validate_changelog_contents_one_header_format
     assert_nothing_raised do
       contents = "## 1.1.1\ncontents"
       expected_current_release = CurrentRelease.new("1.1.1", "contents")
+      actual_current_release = @validator_changelog.validate_changelog_contents(contents)
+      assert_equal(expected_current_release.version, actual_current_release.version)
+      assert_equal(expected_current_release.changelog, actual_current_release.changelog)
+    end
+  end
+
+  def test_validate_changelog_contents_one_header_format_with_v_in_front
+    assert_nothing_raised do
+      contents = "## v1.1.1\ncontents"
+      expected_current_release = CurrentRelease.new("v1.1.1", "contents")
       actual_current_release = @validator_changelog.validate_changelog_contents(contents)
       assert_equal(expected_current_release.version, actual_current_release.version)
       assert_equal(expected_current_release.changelog, actual_current_release.changelog)


### PR DESCRIPTION
### Problem

Certain repositories (for historical reasons) use "vX.Y.Z" for their version names in the CHANGELOG (and subsequent git tag). Need to allow for that.

### Solution

Allow an optional `v` in the regular expression.
